### PR TITLE
Print all version numbers in decimal.

### DIFF
--- a/wacom_flash/wacom_flash.c
+++ b/wacom_flash/wacom_flash.c
@@ -889,7 +889,7 @@ int main(int argc, char *argv[])
 		goto err;
 	}
 
-	fprintf(stderr,  "Flashed firmware : %x \n", current_fw_ver);
+	fprintf(stderr,  "Flashed firmware : %d \n", current_fw_ver);
 #endif
 
 	ret = 0;


### PR DESCRIPTION
This CL reverts a recent change that makes firmware versions appear in
hexidecimal again when performing a FW update.  This is confusing to have
the version number sometimes in hex and sometimes in decimal if it isn't
preceded by 0x there's no way to tell the difference, so let's just use
decimal to be consistent.

Signed-off-by: Charlie Mooney charliemooney@chromium.org
